### PR TITLE
fix rule34.xxx tags

### DIFF
--- a/src/modules/rule34_xxx.ts
+++ b/src/modules/rule34_xxx.ts
@@ -91,10 +91,10 @@ export class ModuleRule34XXX extends AbstractModule {
             const tagsOfCategory: Tag[] = []
             let els = sidebarEl.querySelectorAll(tagLiClass)
             els.forEach((el) => {
-                const a = el.querySelector('a')
+                const a = el.querySelectorAll('a')[1]
                 if (!a || !a.textContent) {return}
                 const enTag: string = a.textContent.trim().replaceAll(' ', '_')
-                const span = el.querySelector('span')
+                const span = el.querySelector('.tag-count')
                 if (!span || !span.textContent) {return}
                 const count: number = ~~span.textContent
                 tagsOfCategory.push({ en: enTag, count })


### PR DESCRIPTION
el.querySelector('a') selects the wiki link instead of the actual tag, that's why all tags were question marks