### PR TITLE
feat: Add %artists% filename token

### DIFF
--- a/src/content.ts
+++ b/src/content.ts
@@ -116,6 +116,10 @@ function generateFileBaseNameByTags(tagDict: FileTags): string {
     const artistInFn: string = tagDict.artist[0] ? tagDict.artist[0].en : ''
     const studioInFn: string = tagDict.studio[0] ? tagDict.studio[0].en : ''
     fname = templateReplacer(fname, 'artist', artistInFn || studioInFn || 'unknown_artist')
+    const artistsInFn: string = tagDict.artist[0] ? tagDict.artist.map((tag) => tag.en).join(',') : 'unknown_artists'
+    fname = templateReplacer(fname, 'artists', artistsInFn)
+    const studiosInFn: string = tagDict.studio[0] ? tagDict.studio.map((tag) => tag.en).join(',') : 'no_studios'
+    fname = templateReplacer(fname, 'studios', studiosInFn)
     const copyrightInFn: string = tagDict.copyright[0] ? tagDict.copyright[0].en : 'no series'
     fname = templateReplacer(fname, 'series', copyrightInFn)
     const characterInFn: string = tagDict.character[0] ? tagDict.character[0].en : ''

--- a/src/options.ts
+++ b/src/options.ts
@@ -13,6 +13,8 @@ export const FilenameTemplateTokenDict = {
     'sitefullname': "Site's full name. For example, <code>SankakuComplex</code>",
     'postid': "Post's ID number it that site. For example: <code>123456</code>",
     'artist': `The tag "artist" or "studio". If not found, show <code>unknown_artist</code>. If found multiple, use artist first, or use the one with the most posts count.`,
+    'artists': `The full list of "artist"s. If not found, show <code>unkown_artists</code>.`,
+    'studios': `The full list of "studio"s. If not found, show <code>no_studios</code>.`,
     'series': `The canonical Booru tag is "copyright", that is "series" (ex: <code>k-on!</code>). If not found, show <code>no_series</code>. If found multiple, use the one with the most posts count.`,
     'character': `The tag "character". If not found, show <code>no_character</code>. If found multiple, use the one with the most posts count.`,
     'generals': `The tag "generals". This always pick multiple tags with <b>least</b> posts count, until the file name length limit reached.`,


### PR DESCRIPTION
Adds the `%artists%` token which is a comma seperated list of artists and studios.

I'm not sure if this is how it should be implemented in the token system, considering no other token handles multiple values, but I think that the `%artist%` token is too error-prone for such an important metadata field.  Maybe another token system design for multiple values may be considered in a different scope.